### PR TITLE
ordersテーブルの修正

### DIFF
--- a/db/migrate/20250114072346_create_orders.rb
+++ b/db/migrate/20250114072346_create_orders.rb
@@ -11,7 +11,7 @@ class CreateOrders < ActiveRecord::Migration[6.1]
       t.integer :postage, null: false
       t.integer :payment_method, null: false
       t.integer :total_payment, null: false
-      t.integer :status, null: false, default: "0" 
+      t.integer :status, null: false, default: 0
     end
   end
 end


### PR DESCRIPTION
defaultが文字列になっていた為、「”　”（ダブルクォーテーション）」を削除しました。